### PR TITLE
BUGFIX: runic parse renders '%' and '#' out of order on page '#xbl3'

### DIFF
--- a/lib/runic.js
+++ b/lib/runic.js
@@ -50,7 +50,7 @@ function Runic(raw)
     var lines = raw;
     var lines = !Array.isArray(raw) ? raw.split("\n") : raw;
 
-    for(id in lines)
+    for(let id in lines)
     {
       var char = lines[id].substr(0,1).trim().toString()
       var rune = this.runes[char];
@@ -85,7 +85,7 @@ function Runic(raw)
     var stash = this.stash.pop();
 
     var html = "";
-    for(id in stash){
+    for(let id in stash){
       var rune = stash[id].rune;
       var line = stash[id].item;
       html += rune.wrap ? `<${rune.sub}><${rune.wrap}>${line.replace(/\|/g,`</${rune.wrap}><${rune.wrap}>`).trim()}</${rune.wrap}></${rune.sub}>` : `<${rune.sub}>${line}</${rune.sub}>`;  
@@ -104,7 +104,7 @@ function Runic(raw)
   this.media = function(val)
   {
     var service = val.split(" ")[0];
-    var id = val.split(" ")[1];
+    let id = val.split(" ")[1];
 
     if(service == "itchio"){
       return `<iframe frameborder="0" src="https://itch.io/embed/${id}?bg_color=262626&amp;fg_color=e4e4e3&amp;link_color=e4e4e3&amp;border_color=262626&amp" width="600" height="167"></iframe>`;
@@ -166,7 +166,7 @@ String.prototype.to_markup = function()
   html = html.replace(/{\#/g,"<code class='inline'>").replace(/\#}/g,"</code>")
 
   var parts = html.split("{{")
-  for(id in parts){
+  for(let id in parts){
     var part = parts[id];
     if(part.indexOf("}}") == -1){ continue; }
     var content = part.split("}}")[0];

--- a/lib/runic.js
+++ b/lib/runic.js
@@ -50,12 +50,22 @@ function Runic(raw)
     var lines = raw;
     var lines = !Array.isArray(raw) ? raw.split("\n") : raw;
 
-    for(id in lines){
+    for(id in lines)
+    {
       var char = lines[id].substr(0,1).trim().toString()
       var rune = this.runes[char];
+
       var trail = lines[id].substr(1,1);
-      if(char == "%"){ html += this.media(lines[id].substr(2)); continue; }
-      if(char == "@"){ html += this.quote(lines[id].substr(2)); continue; }
+      if(char == "%"){
+        if(this.stash.is_pop(rune)){ html += this.render_stash(); }
+        html += this.media(lines[id].substr(2));
+        continue;
+      }
+      if(char == "@"){
+        if(this.stash.is_pop(rune)){ html += this.render_stash(); }
+        html += this.media(lines[id].substr(2));
+        continue;
+      }
       var line = lines[id].substr(2).to_markup();
       if(!line || line.trim() == ""){ continue; }
       if(!rune){ console.log(`Unknown rune:${char} : ${line}`); }


### PR DESCRIPTION
Media/quote rendering needed to render the runic stash (if available) prior to their media/quote item.

Also it seems the many different 'var id' variables were interfering with each other. If you just check out 25d12c2 you'll see the first image on the #xbl3 page gets the wrong data passed to it, however after the 'let id' fixes in fe5e645  the page loads correctly.